### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules
 dist
 .nyc_output
 coverage


### PR DESCRIPTION
Once you run "npm i" you get all the node_modules as "Untracked files"