### PR TITLE
Add support for other file extensions (`.jsx`, `.ts`,  and`.tsx`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Run `pixo --help` to see the list of options.
 -i --index            Include index.js barrel module
 -c --icon-component   Include wrapper Icon.js component
 -r --recursive        Recursively read all SVGs in subdirectories
+-f --fileType         Specify JavaScript/jsx or TypeScript/tsx by name or extension. Default JavaScript.
 ```
 
 **Example `package.json`**

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Run `pixo --help` to see the list of options.
 - `index` (boolean) create an `index.js` barrel module
 - `iconComponent` (boolean) create an `Icon.js` wrapper component
 - `recursive` (boolean) recursively read all SVGs in subdirectories
+- `fileType`  (string) Specifies a file type to output all generated SVGs, defaulting to .js
 
 **CLI flags**
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -109,7 +109,7 @@ const validateFileType = {
 	'.ts': '.ts',
 	'typescript': '.ts',
 
-	'tsx': 'tsx',
+	'tsx': '.tsx',
 	'.tsx': '.tsx'
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -31,6 +31,10 @@ const cli = meow(`
 `, {
   booleanDefault: undefined,
   flags: {
+	fileType: {
+	  type: 'string',
+	  alias: 'f'
+	},
     outDir: {
       type: 'string',
       alias: 'd'
@@ -93,6 +97,22 @@ const readFile = file => {
 
 const ignore = (file, stats) => !stats.isDirectory() && !/\.svg$/.test(file)
 
+const validateFileType = {
+	'.js': '.js',
+	'js': '.js',
+	'javascript': '.js',
+
+	'jsx': '.jsx',
+	'.jsx': '.jsx',
+
+	'ts': '.ts',
+	'.ts': '.ts',
+	'typescript': '.ts',
+
+	'tsx': 'tsx',
+	'.tsx': '.tsx'
+}
+
 const convert = async (opts) => {
   const readdir = opts.recursive
     ? async dirname => recursiveReaddir(dirname, [ ignore ])
@@ -113,7 +133,7 @@ const convert = async (opts) => {
     fs.mkdirSync(opts.outDir)
   }
   components.forEach(({ name, content }) => {
-    const filename = path.join(opts.outDir, name + '.js')
+    const filename = path.join(opts.outDir, name + (validateFileType[opts.fileType] || '.js'))
     fs.writeFileSync(filename, content)
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixo",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Convert SVG icons into React components",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Convert SVG icons into React components",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Thanks for building pixo! We've been successfully using it for a long time now. Recently we started migrating our codebase to TypeScript and thought it'd be nice if the icon components were TypeScript files, too. So here's a little PR that adds the ability to customise the file extension for generated icons.